### PR TITLE
Enable LTO for the client to cut the WASM output size by 10x (2.6MB -> 260KB)

### DIFF
--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -9,3 +9,6 @@ yew = "=0.4.0"
 protobuf = "=1.7.3"
 failure = "=0.1.1"
 stdweb = "=0.4.6"
+
+[profile.release]
+lto = true


### PR DESCRIPTION
More details:

* https://internals.rust-lang.org/t/full-std-crate-is-linked-accidentally-in-wasm-binary/7847/5
* https://github.com/rust-lang/rust/pull/48125#issuecomment-364679159